### PR TITLE
Fix bug preventing undedicated players from placing on claim bastions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.wezro</groupId>
     <artifactId>dedication</artifactId>
-    <version>1.3.2</version>
+    <version>1.3.3</version>
     <packaging>jar</packaging>
     <dependencies>
     	<dependency>
@@ -33,7 +33,7 @@
         <dependency>
         	<groupId>isaac</groupId>
         	<artifactId>Bastion</artifactId>
-        	<version>2.0.2</version>
+        	<version>2.0.8</version>
         	<scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/psygate/dedication/listeners/BastionListener.java
+++ b/src/main/java/com/psygate/dedication/listeners/BastionListener.java
@@ -2,6 +2,7 @@ package com.psygate.dedication.listeners;
 
 import com.psygate.dedication.Dedication;
 import isaac.bastion.Bastion;
+import isaac.bastion.listeners.BastionDamageListener;
 import isaac.bastion.manager.BastionBlockManager;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
@@ -43,6 +44,9 @@ public class BastionListener implements Listener
 
         //See if there are any bastions covering this location that the player is not on the groups for
         Set blocking = bastionManager.shouldStopBlock(null, blocks, event.getPlayer().getUniqueId());
+        
+        //Clear out bastions that can only be directly destroyed
+        blocking = BastionDamageListener.clearNonBlocking(blocking);
 
         //We have already determined the player is not dedicated, so if there are blocking bastions
         //we cancel the event.


### PR DESCRIPTION
So earlier today I decided to log into Devoted for the first time in a few weeks. I talked a bit to a few nice people and was invited to build a house in Mount Augusta. I finally managed to get to MTA after getting killed by overpowered mobs multiple times (which I probably really deserve) and intended to start harvesting wood for my house. Sadly I realized that even though I got added to the cities bastion group, I was not able to replant saplings, it kept telling me I was not dedicated. I was told that there was an issue with dedication and bastions and that I should just get dedicated so I could place those saplings. I decided to instead fix the underlying issue, because fuck dedication.

I looked at https://github.com/DevotedMC/Bastion/blob/master/src/main/java/isaac/bastion/listeners/BastionDamageListener.java#L46 and https://github.com/DevotedMC/dedication/blob/master/src/main/java/com/psygate/dedication/listeners/BastionListener.java#L35 to check what Bastion and dedication were doing differently to determine whether a player is allowed to place. The only difference was that dedication wasnt calling this method https://github.com/DevotedMC/Bastion/blob/master/src/main/java/isaac/bastion/listeners/BastionDamageListener.java#L211, which filters out bastions for which 'onlyDirectDestroy' is set to true. I dont even know what that means, but it's set for the claims bastion I'm trying to plant on. I confirmed that I can place on 'real' bastions, but not on claims bastions by using /bsi.

So the fix here is to call that method in dedication the same way it is called in Bastion. I'll also make a PR in Bastion to make that method public and static (which it should be anyway).

Merge please, I need wood for my house.